### PR TITLE
A couple of improvements

### DIFF
--- a/src/hook.c
+++ b/src/hook.c
@@ -451,7 +451,10 @@ MH_STATUS WINAPI MH_Initialize(VOID)
 
     g_hHeap = HeapCreate(0, 0, 0);
     if (g_hHeap == NULL)
+    {
+        DeleteCriticalSection(&g_cs);
         return MH_ERROR_MEMORY_ALLOC;
+    }
 
     // Initialize the internal function buffer.
     InitializeBuffer();


### PR DESCRIPTION
First of all, great job on the new version!

I did a quick pass on `hook.c`, and made some improvements. I put them all in one pull requests because I find it more convenient for me, but if you'd like me to separate it to different pull requests, let me know. Also, please note that I have only briefly tested the changes.

A couple of additional notes:
- I don't like the inconsistency of the memory manipulation functions used: `memcpy`, `__stosb`, `RtlMoveMemory`. Why not use `memcpy`, `memset`, `memmove`?
- All those `__try`/`__except`-s for `InitializeCriticalSection`/`EnterCriticalSection`, why are they needed?
- You do a check for `if (g_hHeap == NULL)` in all `MH_*` functions, but if MinHook is not initialized, `EnterCriticalSection` will fail a couple of lines above. So what is the check good for? If there's no graceful way to check for the case where the library is uninitialized, perhaps it should be dropped altogether.
- I'm not sure that wrapping `MH_CreateHook` with `__try`/`__except` is a good idea.
