### PR TITLE
Add function to translate status value to string

### DIFF
--- a/include/MinHook.h
+++ b/include/MinHook.h
@@ -160,6 +160,9 @@ extern "C" {
     // Applies all queued changes in one go.
     MH_STATUS WINAPI MH_ApplyQueued(VOID);
 
+    // Translates the MH_STATUS to its name as a string.
+    const char * WINAPI MH_StatusToString(MH_STATUS status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hook.c
+++ b/src/hook.c
@@ -843,3 +843,30 @@ MH_STATUS WINAPI MH_CreateHookApi(
 
     return MH_CreateHook(pTarget, pDetour, ppOriginal);
 }
+
+//-------------------------------------------------------------------------
+const char * WINAPI MH_StatusToString(MH_STATUS status)
+{
+    #define MH_ST2STR(x) \
+    case x: \
+        return #x;
+
+    switch (status) {
+        MH_ST2STR(MH_UNKNOWN)
+        MH_ST2STR(MH_OK)
+        MH_ST2STR(MH_ERROR_ALREADY_INITIALIZED)
+        MH_ST2STR(MH_ERROR_NOT_INITIALIZED)
+        MH_ST2STR(MH_ERROR_ALREADY_CREATED)
+        MH_ST2STR(MH_ERROR_NOT_CREATED)
+        MH_ST2STR(MH_ERROR_ENABLED)
+        MH_ST2STR(MH_ERROR_DISABLED)
+        MH_ST2STR(MH_ERROR_NOT_EXECUTABLE)
+        MH_ST2STR(MH_ERROR_UNSUPPORTED_FUNCTION)
+        MH_ST2STR(MH_ERROR_MEMORY_ALLOC)
+        MH_ST2STR(MH_ERROR_MEMORY_PROTECT)
+    }
+
+#undef MH_ST2STR
+
+    return "(unknown)";
+}


### PR DESCRIPTION
Having a helper function to convert the return codes into a print- and readable format can be very helpful for logging and debugging.
Rather than every user of the MinHook library implementing this on their own, it would be very useful to be provided by MinHook itself.

This commit adds the helper function MH_StatusToString, which converts an MH_STATUS to its enum variable name as a `char*` string.