### PR TITLE
Compatibility with UNIX build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ obj/
 [Dd]ebug*/
 [Rr]elease*/
 Ankh.NoLoad
+
+#GCC files
+*.o
+*.d
+*.res
+*.dll
+*.a

--- a/build/MinGW/Makefile
+++ b/build/MinGW/Makefile
@@ -1,0 +1,33 @@
+WINDRES:=$(CROSS_PREFIX)windres
+DLLTOOL:=$(CROSS_PREFIX)dlltool
+AR:=$(CROSS_PREFIX)ar
+CC:=$(CROSS_PREFIX)gcc
+CCLD:=$(CC)
+SRCS:=$(wildcard src/*.c src/HDE/*.c)
+OBJS:=$(SRCS:%.c=%.o)
+DEPS:=$(SRCS:%.c=%.d)
+INCS:=-Isrc -Iinclude
+CFLAGS:=-masm=intel -Wall -Werror -std=c11
+LDFLAGS:=-Wl,-enable-stdcall-fixup -s -static-libgcc
+
+all: MinHook.dll libMinHook.dll.a libMinHook.a
+
+-include $(DEPS)
+
+libMinHook.a: $(OBJS)
+	$(AR) r $@ $^
+libMinHook.dll.a: MinHook.dll dll_resources/MinHook.def
+	$(DLLTOOL) --dllname MinHook.dll --def dll_resources/MinHook.def --output-lib $@
+MinHook.dll: $(OBJS) dll_resources/MinHook.res dll_resources/MinHook.def
+	$(CCLD) -o $@ -shared $(LDFLAGS) $^
+
+.rc.res:
+	$(WINDRES) -o $@ --input-format=rc --output-format=coff $<
+.c.o:
+	$(CC) -o $@ -c -MMD -MP $(INCS) $(CFLAGS) $<
+
+clean:
+	rm -f $(OBJS) $(DEPS) MinHook.dll libMinHook.dll.a libMinHook.a dll_resources/MinHook.res
+
+.PHONY: clean
+.SUFFIXES: .rc .res

--- a/include/MinHook.h
+++ b/include/MinHook.h
@@ -32,7 +32,7 @@
     #error MinHook supports only x86 and x64 systems.
 #endif
 
-#include <Windows.h>
+#include <windows.h>
 
 // MinHook Error Codes.
 typedef enum MH_STATUS

--- a/src/HDE/pstdint.h
+++ b/src/HDE/pstdint.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 // Integer types for HDE.
 typedef INT8   int8_t;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -29,7 +29,7 @@
 #define STRICT
 #define NOMINMAX
 #define _WIN32_WINNT 0x0501
-#include <Windows.h>
+#include <windows.h>
 #include "buffer.h"
 
 // Size of each memory block. (= page size of VirtualAlloc)

--- a/src/hook.c
+++ b/src/hook.c
@@ -28,8 +28,8 @@
 
 #define STRICT
 #define _WIN32_WINNT 0x0501
-#include <Windows.h>
-#include <TlHelp32.h>
+#include <windows.h>
+#include <tlhelp32.h>
 #include <limits.h>
 
 #include "../include/MinHook.h"

--- a/src/trampoline.c
+++ b/src/trampoline.c
@@ -26,7 +26,7 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <Windows.h>
+#include <windows.h>
 
 #ifndef ARRAYSIZE
     #define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))


### PR DESCRIPTION
Hi.
I fix some problems in UNIX.

First, UNIX is case sensitive. And Mingw's header files are named in lower case.
So fix include sentence.
Windows is case insensitive, so I think it can build in windows too.

Second, make.bat is not incompatible with UNIX.
So I add Makefile for GNU make.

Third, fix gitignore file to ignore result file in UNIX.