### PR TITLE
easy to link library

### DIFF
--- a/include/MinHook.h
+++ b/include/MinHook.h
@@ -34,6 +34,12 @@
 
 #include <windows.h>
 
+#if defined _M_X64
+#pragma comment(lib, "libMinHook.x64.lib")
+#elif defined _M_IX86
+#pragma comment(lib, "libMinHook.x86.lib")
+#endif
+
 // MinHook Error Codes.
 typedef enum MH_STATUS
 {


### PR DESCRIPTION
To be convenient, add linking library code in MinHook.h,
 It makes you use minhook library easily including minhook.h only.
