### PR TITLE
hook: Add MH_CreateHookVirtual for virtual method table hooking.

### DIFF
--- a/include/MinHook.h
+++ b/include/MinHook.h
@@ -141,6 +141,37 @@ extern "C" {
     MH_STATUS WINAPI MH_CreateHookApiEx(
         LPCWSTR pszModule, LPCSTR pszProcName, LPVOID pDetour, LPVOID *ppOriginal, LPVOID *ppTarget);
 
+    // Creates a Hook for the specified virtual method, in disabled state.
+    // Parameters:
+    //   pInstance  [in]  A pointer to the instance of the class which contains the
+    //                    virtual method table.
+    //   methodPos  [in]  The zero-based position of the target method in the table,
+    //                    which will be overridden by the detour function.
+    //   pDetour    [in]  A pointer to the detour function, which will override
+    //                    the target method.
+    //   ppOriginal [out] A pointer to the trampoline function, which will be
+    //                    used to call the original target function.
+    //                    This parameter can be NULL.
+    MH_STATUS WINAPI MH_CreateHookVirtual(
+        LPVOID pInstance, UINT methodPos, LPVOID pDetour, LPVOID *ppOriginal);
+
+    // Creates a Hook for the specified virtual method, in disabled state.
+    // Parameters:
+    //   pInstance  [in]  A pointer to the instance of the class which contains the
+    //                    virtual method table.
+    //   methodPos  [in]  The zero-based position of the target method in the table,
+    //                    which will be overridden by the detour function.
+    //   pDetour    [in]  A pointer to the detour function, which will override
+    //                    the target method.
+    //   ppOriginal [out] A pointer to the trampoline function, which will be
+    //                    used to call the original target function.
+    //                    This parameter can be NULL.
+    //   ppTarget   [out] A pointer to the target function, which will be used
+    //                    with other functions.
+    //                    This parameter can be NULL.
+    MH_STATUS WINAPI MH_CreateHookVirtualEx(
+        LPVOID pInstance, UINT methodPos, LPVOID pDetour, LPVOID *ppOriginal, LPVOID *ppTarget);
+
     // Removes an already created hook.
     // Parameters:
     //   pTarget [in] A pointer to the target function.

--- a/src/hook.c
+++ b/src/hook.c
@@ -860,6 +860,26 @@ MH_STATUS WINAPI MH_CreateHookApi(
 }
 
 //-------------------------------------------------------------------------
+MH_STATUS WINAPI MH_CreateHookVirtualEx(
+    LPVOID pInstance, UINT methodPos, LPVOID pDetour, LPVOID *ppOriginal, LPVOID *ppTarget)
+{
+    LPVOID* pVMT = *((LPVOID**)pInstance);
+    LPVOID  pTarget = pVMT[methodPos];
+
+    if (ppTarget != NULL)
+        *ppTarget = pTarget;
+
+    return MH_CreateHook(pTarget, pDetour, ppOriginal);
+}
+
+//-------------------------------------------------------------------------
+MH_STATUS WINAPI MH_CreateHookVirtual(
+    LPVOID pInstance, UINT methodPos, LPVOID pDetour, LPVOID *ppOriginal)
+{
+    return MH_CreateHookVirtualEx(pInstance, methodPos, pDetour, ppOriginal, NULL);
+}
+
+//-------------------------------------------------------------------------
 const char * WINAPI MH_StatusToString(MH_STATUS status)
 {
 #define MH_ST2STR(x)    \


### PR DESCRIPTION
Since there is an `MH_CreateHookApi` convenience function, I thought it would be nice to add a convenience function for VTable hooking.