### PR TITLE
Uninitialized global variable

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -62,7 +62,7 @@ typedef struct _MEMORY_BLOCK
 //-------------------------------------------------------------------------
 
 // First element of the memory block list.
-PMEMORY_BLOCK g_pMemoryBlocks;
+PMEMORY_BLOCK g_pMemoryBlocks = NULL;
 
 //-------------------------------------------------------------------------
 VOID InitializeBuffer(VOID)


### PR DESCRIPTION
Avoid possible exception on 175+ line, g_pMemoryBlocks may contains garbage with some compilation flags.