### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,13 @@ I need some funds to continue developing this library. All contributions gratefu
  
   * Initial release.
 
-### Building minhook - Using vcpkg
+### Building MinHook - Using vcpkg
 
-You can download and install minhook using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install MinHook using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install minhook
+    git clone https://github.com/microsoft/vcpkg
+    .\vcpkg\bootstrap-vcpkg.bat
+    .\vcpkg\vcpkg integrate install
+    .\vcpkg\vcpkg install minhook
 
-The minhook port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The MinHook port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.md
+++ b/README.md
@@ -86,3 +86,15 @@ I need some funds to continue developing this library. All contributions gratefu
 - **v1.0 - 22 Nov 2009**
  
   * Initial release.
+
+### Building minhook - Using vcpkg
+
+You can download and install minhook using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install minhook
+
+The minhook port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
Minhook is available as a port in vcpkg, a C++ library manager that simplifies installation for minhook and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build minhook, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.