### PR TITLE
Fix __movsb not compiling with MSVC due to incompatible type

### DIFF
--- a/src/trampoline.c
+++ b/src/trampoline.c
@@ -280,7 +280,7 @@ BOOL CreateTrampolineFunction(PTRAMPOLINE ct)
 #ifndef _MSC_VER
         memcpy((LPBYTE)ct->pTrampoline + newPos, pCopySrc, copySize);
 #else
-        __movsb((LPBYTE)ct->pTrampoline + newPos, pCopySrc, copySize);
+        __movsb((LPBYTE)ct->pTrampoline + newPos, (BYTE*)pCopySrc, copySize);
 #endif
         newPos += copySize;
         oldPos += hs.len;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63328889/124398402-d3a83500-dd15-11eb-8b78-b8c004c46d5f.png)
