### PR TITLE
Fixed CMake failing to configure on UNIX environment 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ endif()
 
 if(BUILD_SHARED_LIBS)
   set(RESOURCES 
-    "dll_resources/minhook.rc"
-    "dll_resources/minhook.def"
+    "dll_resources/MinHook.rc"
+    "dll_resources/MinHook.def"
   )
 endif()
 


### PR DESCRIPTION
CMake project fails to configure on UNIX environment, since files in dll_resources folder has capitalized `MinHook.*` name as opposed to what is specified in CMake, which is lowercase `minhook.*`. Since Linux system is case-sensitive unlike Windows, this causes CMake to fail to look for the required files and as a result, fail to configure the project.

This pull request fixes that by updating CMakeLists.txt to have capitalized path specified. This change is trivial and shouldn't cause issues on Windows. Tested on Fedora 37 with Fedora MinGW 12.2.1-3 and CMake 3.24.1.