### PR TITLE
Define p at start of EnumerateThreads function.

### DIFF
--- a/src/hook.c
+++ b/src/hook.c
@@ -262,6 +262,7 @@ static VOID ProcessThreadIPs(HANDLE hThread, UINT pos, UINT action)
 //-------------------------------------------------------------------------
 static BOOL EnumerateThreads(PFROZEN_THREADS pThreads)
 {
+	LPDWORD p;
     BOOL succeeded = FALSE;
 
     HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
@@ -292,7 +293,7 @@ static BOOL EnumerateThreads(PFROZEN_THREADS pThreads)
                     else if (pThreads->size >= pThreads->capacity)
                     {
                         pThreads->capacity *= 2;
-                        LPDWORD p = (LPDWORD)HeapReAlloc(
+                        p = (LPDWORD)HeapReAlloc(
                             g_hHeap, 0, pThreads->pItems, pThreads->capacity * sizeof(DWORD));
                         if (p == NULL)
                         {


### PR DESCRIPTION
Fixes build on older compilers.