### PR TITLE
Cross Compilation from Linux to Windows via mingw

### DIFF
--- a/build/MinGW/make.sh
+++ b/build/MinGW/make.sh
@@ -1,0 +1,2 @@
+x86_64-w64-mingw32-windres -i ../../dll_resources/MinHook.rc -o MinHook_rc.o &&
+x86_64-w64-mingw32-dllwrap -o MinHook.dll -masm=intel --def ../../dll_resources/MinHook.def -Wl,-enable-stdcall-fixup -Wall MinHook_rc.o ../../src/*.c ../../src/hde/*.c -I../../include -I../../src -Werror -s -static-libgcc -static-libstdc++


### PR DESCRIPTION
Adds support to cross compile MinGW from Linux as the host system to Windows.
Changes made include

-  using x86_64-w64-mingw32-windres and x86_64-w64-mingw32-dllwrap
- remove -std=c++11 
- rename the HDE dir to hde due to Linux being case sensitive

Compiles without a problem on ubuntu 24.04